### PR TITLE
Introduce File[Wrapper]

### DIFF
--- a/app/src/main/java/com/teixeira/vcspace/activities/EditorActivity.kt
+++ b/app/src/main/java/com/teixeira/vcspace/activities/EditorActivity.kt
@@ -72,6 +72,9 @@ import com.teixeira.vcspace.editor.events.OnKeyBindingEvent
 import com.teixeira.vcspace.events.OnOpenFolderEvent
 import com.teixeira.vcspace.extensions.open
 import com.teixeira.vcspace.extensions.toFile
+import com.teixeira.vcspace.file.File
+import com.teixeira.vcspace.file.extension
+import com.teixeira.vcspace.file.wrapFile
 import com.teixeira.vcspace.github.auth.Api
 import com.teixeira.vcspace.github.auth.UserInfo
 import com.teixeira.vcspace.keyboard.CommandPaletteManager
@@ -89,7 +92,6 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import java.io.File
 
 object Editor {
   val LocalEditorDrawerState = compositionLocalOf<DrawerState> {
@@ -357,11 +359,11 @@ class EditorActivity : BaseComposeActivity() {
 
             if (manifest != null) {
               val pluginPath = "$pluginsPath/${manifest.packageName}"
-              val filesToOpen = arrayOf(
-                "$pluginPath/manifest.json".toFile(),
-                "$pluginPath/${manifest.scripts.first().name}".toFile()
+              val filesToOpen = listOf(
+                "$pluginPath/manifest.json".toFile().wrapFile(),
+                "$pluginPath/${manifest.scripts.first().name}".toFile().wrapFile()
               )
-              editorViewModel.addFiles(*filesToOpen)
+              editorViewModel.addFiles(filesToOpen)
             }
           }
 
@@ -369,7 +371,7 @@ class EditorActivity : BaseComposeActivity() {
           if (externalFileUri != null &&
             !externalFileUri.toString().startsWith(BuildConfig.OAUTH_REDIRECT_URL)
           ) {
-            editorViewModel.addFile(UriUtils.uri2File(externalFileUri))
+            editorViewModel.addFile(UriUtils.uri2File(externalFileUri).wrapFile())
           }
 
           onCreate()

--- a/app/src/main/java/com/teixeira/vcspace/app/app.kt
+++ b/app/src/main/java/com/teixeira/vcspace/app/app.kt
@@ -15,7 +15,7 @@
 
 package com.teixeira.vcspace.app
 
-import java.io.File
+import com.teixeira.vcspace.file.File
 
 typealias DoNothing = Unit
 typealias Folder = File

--- a/app/src/main/java/com/teixeira/vcspace/core/components/file/FileList.kt
+++ b/app/src/main/java/com/teixeira/vcspace/core/components/file/FileList.kt
@@ -67,10 +67,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.providers.FileIconProvider
 import com.teixeira.vcspace.resources.R
 import com.teixeira.vcspace.ui.screens.editor.EditorViewModel
-import java.io.File
 import java.text.SimpleDateFormat
 import kotlin.math.max
 

--- a/app/src/main/java/com/teixeira/vcspace/events/fileEvents.kt
+++ b/app/src/main/java/com/teixeira/vcspace/events/fileEvents.kt
@@ -1,7 +1,7 @@
 package com.teixeira.vcspace.events
 
 import com.teixeira.vcspace.app.Folder
-import java.io.File
+import com.teixeira.vcspace.file.File
 
 data class OnDeleteFileEvent(val file: File, val openedFolder: File)
 

--- a/app/src/main/java/com/teixeira/vcspace/file/DocumentFileWrapper.kt
+++ b/app/src/main/java/com/teixeira/vcspace/file/DocumentFileWrapper.kt
@@ -15,6 +15,7 @@
 
 package com.teixeira.vcspace.file
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
@@ -32,6 +33,8 @@ data class DocumentFileWrapper(
     get() = raw.uri.toString()
   override val canonicalPath: String
     get() = raw.uri.toString()
+  override val canRestoreFromPath: Boolean
+    get() = false
   private val _isDirectory = lazy { raw.isDirectory }
   override val isDirectory: Boolean
     get() = _isDirectory.value
@@ -104,5 +107,17 @@ data class DocumentFileWrapper(
       outputStream?.close()
     }
     true
+  }
+
+  companion object {
+    /**
+     * true if [DocumentFileWrapper] should be used.
+     *
+     * The implementation is conservative as a lot of functionality stops working
+     * when [DocumentFileWrapper] is used. The target implementation will accept all
+     * content uris for custom [androidx.core.content.FileProvider]s.
+     */
+    fun shouldWrap(uri: Uri): Boolean
+      = ContentResolver.SCHEME_CONTENT == uri.scheme && "com.termux.documents" == uri.host
   }
 }

--- a/app/src/main/java/com/teixeira/vcspace/file/DocumentFileWrapper.kt
+++ b/app/src/main/java/com/teixeira/vcspace/file/DocumentFileWrapper.kt
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Visual Code Space.
+ *
+ * Visual Code Space is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Visual Code Space is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Visual Code Space.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.teixeira.vcspace.file
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+
+data class DocumentFileWrapper(
+  private val raw: DocumentFile,
+  private val isDocumentTree: Boolean = false,
+): File {
+  override val absolutePath: String
+    get() = raw.uri.toString()
+  override val canonicalPath: String
+    get() = raw.uri.toString()
+  private val _isDirectory = lazy { raw.isDirectory }
+  override val isDirectory: Boolean
+    get() = _isDirectory.value
+  private val _isFile = lazy { raw.isFile }
+  override val isFile: Boolean
+    get() = _isFile.value
+  /**
+   * This needs to be consolidated with the same method as [JavaFileWrapper.isValidText]
+   */
+  override val isValidText: Boolean
+    get() = true
+  private val _name = lazy { raw.name ?: "(unknown)" }
+  override val name: String
+    get() = _name.value
+  override val mimeType: String?
+    get() = raw.type
+  override val parent: String?
+    get() = raw.parentFile?.uri?.toString()
+  override val parentFile: File?
+    get() = raw.parentFile?.let { DocumentFileWrapper(it) }
+  override val path: String
+    get() = raw.uri.path ?: "UNKNOWN"
+
+  override fun asRawFile(): java.io.File? = null
+
+  override fun childExists(childName: String): Boolean
+    = raw.findFile(childName) != null
+
+  override fun createNewFile(fileName: String): File?
+    = raw.createFile("", fileName)?.let { DocumentFileWrapper(it) }
+
+  override fun createNewDirectory(fileName: String): File?
+    = raw.createDirectory(fileName)?.let { DocumentFileWrapper(it) }
+
+  override fun delete(): Boolean = raw.delete()
+
+  override fun exists(): Boolean = raw.exists()
+
+  override fun lastModified(): Long = raw.lastModified()
+
+  override fun listFiles(): Array<out File>
+    = raw.listFiles().map { DocumentFileWrapper(it) }.toTypedArray()
+
+  override fun renameTo(newName: String): File? =
+    if (raw.renameTo(newName)) {
+      this
+    } else null
+
+  override fun uri(context: Context): Uri = raw.uri
+
+  override suspend fun readFile2String(context: Context): String {
+    val inputStream = context.contentResolver.openInputStream(raw.uri)
+    val reader = BufferedReader(InputStreamReader(inputStream))
+    return reader.readLines().joinToString("\n")
+  }
+
+  override suspend fun write(
+    context: Context,
+    content: String,
+    ioDispatcher: CoroutineDispatcher,
+  ): Boolean = withContext(ioDispatcher) {
+    var outputStream: OutputStream? = null
+    try {
+      outputStream = context.contentResolver.openOutputStream(raw.uri,"wt")
+      val checkedOutputStream = outputStream ?: return@withContext false
+      checkedOutputStream.write(content.toByteArray())
+    } catch (t : Throwable) {
+      return@withContext false
+    } finally {
+      outputStream?.close()
+    }
+    true
+  }
+}

--- a/app/src/main/java/com/teixeira/vcspace/file/JavaFileWrapper.kt
+++ b/app/src/main/java/com/teixeira/vcspace/file/JavaFileWrapper.kt
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Visual Code Space.
+ *
+ * Visual Code Space is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Visual Code Space is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Visual Code Space.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.teixeira.vcspace.file
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import androidx.core.content.FileProvider
+import com.blankj.utilcode.util.FileIOUtils
+import com.teixeira.vcspace.utils.isValidTextFile
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.util.Locale
+
+internal data class JavaFileWrapper(
+  private val raw: java.io.File
+) : File {
+  override val absolutePath: String
+    get() = raw.absolutePath
+  override val canonicalPath: String
+    get() = raw.canonicalPath
+  override val isDirectory: Boolean
+    get() = raw.isDirectory
+  override val isFile: Boolean
+    get() = raw.isFile
+  override val isValidText: Boolean
+    get() = isValidTextFile(raw)
+  override val name: String
+    get() = raw.name
+  override val mimeType: String
+    get() {
+      val lastDot = name.lastIndexOf('.')
+      if (lastDot >= 0) {
+        val extension = name.substring(lastDot + 1).lowercase(Locale.getDefault())
+        val mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+        if (mime != null) {
+          return mime
+        }
+      }
+      return "application/octet-stream"
+    }
+  override val parent: String?
+    get() = raw.parent
+  override val parentFile: File?
+    get() = raw.parentFile?.let { JavaFileWrapper(it) }
+  override val path: String
+    get() = raw.path
+
+  override fun asRawFile(): java.io.File = raw
+
+  override fun childExists(childName: String): Boolean = java.io.File(raw, childName).exists()
+
+  override fun createNewFile(fileName: String): File? {
+    val target = java.io.File(raw, fileName)
+    try {
+      target.createNewFile()
+      return JavaFileWrapper(target)
+    } catch (e: IOException) {
+      return null
+    }
+  }
+
+  override fun createNewDirectory(fileName: String): File? {
+    val target = java.io.File(raw, fileName)
+    try {
+      target.mkdirs()
+      return JavaFileWrapper(target)
+    } catch (e: IOException) {
+      return null
+    }
+  }
+  override fun delete(): Boolean = raw.delete()
+
+  override fun exists(): Boolean = raw.exists()
+
+  override fun lastModified(): Long =
+    raw.lastModified()
+
+  override fun listFiles(): Array<out File>?
+    = raw.listFiles()?.map { JavaFileWrapper(it) }?.toTypedArray()
+
+  override fun renameTo(newName: String): File? {
+    val dest = java.io.File(raw.parentFile, newName)
+    return if (raw.renameTo(dest)) JavaFileWrapper(dest) else null
+  }
+
+  override fun uri(context: Context): Uri =
+    FileProvider.getUriForFile(
+      context,
+      "$context.packageName.provider",
+      raw
+    )
+
+  override suspend fun readFile2String(context: Context): String?
+    = FileIOUtils.readFile2String(raw)
+
+  override suspend fun write(
+    context: Context,
+    content: String,
+    ioDispatcher: CoroutineDispatcher,
+  ): Boolean = withContext(ioDispatcher) {
+    FileIOUtils.writeFileFromString(raw, content)
+  }
+}
+
+/**
+ * Wrap [java.io.File] with [JavaFileWrapper]
+ */
+fun java.io.File.wrapFile(): File = JavaFileWrapper(this)

--- a/app/src/main/java/com/teixeira/vcspace/file/JavaFileWrapper.kt
+++ b/app/src/main/java/com/teixeira/vcspace/file/JavaFileWrapper.kt
@@ -33,6 +33,8 @@ internal data class JavaFileWrapper(
     get() = raw.absolutePath
   override val canonicalPath: String
     get() = raw.canonicalPath
+  override val canRestoreFromPath: Boolean
+    get() = true
   override val isDirectory: Boolean
     get() = raw.isDirectory
   override val isFile: Boolean

--- a/app/src/main/java/com/teixeira/vcspace/plugins/helper/EditorHelper.java
+++ b/app/src/main/java/com/teixeira/vcspace/plugins/helper/EditorHelper.java
@@ -17,9 +17,8 @@ package com.teixeira.vcspace.plugins.helper;
 
 import com.teixeira.vcspace.activities.EditorActivity;
 import com.teixeira.vcspace.editor.VCSpaceEditor;
+import com.teixeira.vcspace.file.File;
 import com.teixeira.vcspace.ui.screens.editor.components.view.CodeEditorView;
-
-import java.io.File;
 
 public class EditorHelper {
   private final EditorActivity editorActivity;

--- a/app/src/main/java/com/teixeira/vcspace/providers/FileIconProvider.kt
+++ b/app/src/main/java/com/teixeira/vcspace/providers/FileIconProvider.kt
@@ -3,10 +3,11 @@ package com.teixeira.vcspace.providers
 import android.annotation.SuppressLint
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.teixeira.vcspace.file.File
+import com.teixeira.vcspace.file.extension
 import com.teixeira.vcspace.app.BaseApplication.Companion.instance as app
 import com.teixeira.vcspace.models.FileIcon
 import com.teixeira.vcspace.resources.R
-import java.io.File
 
 /**
  * Class to provide File icons

--- a/app/src/main/java/com/teixeira/vcspace/ui/filetree/FileNodeGenerator.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/filetree/FileNodeGenerator.kt
@@ -15,13 +15,15 @@
 
 package com.teixeira.vcspace.ui.filetree
 
+import com.teixeira.vcspace.file.File
 import io.github.dingyi222666.view.treeview.AbstractTree
 import io.github.dingyi222666.view.treeview.Tree
 import io.github.dingyi222666.view.treeview.TreeNode
 import io.github.dingyi222666.view.treeview.TreeNodeGenerator
-import java.io.File
+import kotlinx.coroutines.CoroutineScope
 
 class FileNodeGenerator(
+  private val prefetchScope: CoroutineScope,
   private val rootPath: File,
   private val fileListLoader: FileListLoader
 ) : TreeNodeGenerator<File> {
@@ -36,7 +38,7 @@ class FileNodeGenerator(
       depth = parentNode.depth + 1,
       name = currentData.name,
       id = tree.generateId(),
-      hasChild = currentData.isDirectory && fileListLoader.getCacheFileList(currentData.absolutePath)
+      hasChild = currentData.isDirectory && fileListLoader.getCacheFileList(currentData)
         .isNotEmpty(),
       isChild = currentData.isDirectory,
       expand = false
@@ -44,11 +46,11 @@ class FileNodeGenerator(
   }
 
   override suspend fun fetchChildData(targetNode: TreeNode<File>): Set<File> {
-    val path = targetNode.requireData().absolutePath
+    val path = targetNode.requireData()
     var files = fileListLoader.getCacheFileList(path)
 
     if (files.isEmpty()) {
-      files = fileListLoader.loadFileList(path)
+      files = fileListLoader.loadFileList(prefetchScope, path)
     }
 
     return files.toSet()

--- a/app/src/main/java/com/teixeira/vcspace/ui/filetree/FileViewBinder.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/filetree/FileViewBinder.kt
@@ -36,6 +36,7 @@ import com.teixeira.vcspace.events.OnCreateFileEvent
 import com.teixeira.vcspace.events.OnCreateFolderEvent
 import com.teixeira.vcspace.events.OnDeleteFileEvent
 import com.teixeira.vcspace.events.OnRefreshFolderEvent
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.providers.FileIconProvider
 import io.github.dingyi222666.view.treeview.TreeNode
 import io.github.dingyi222666.view.treeview.TreeNodeEventListener
@@ -47,7 +48,6 @@ import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import java.io.File
 
 class FileViewBinder(
   private val fileTreeBinding: LayoutFileTreeBinding,

--- a/app/src/main/java/com/teixeira/vcspace/ui/git/GitInitSheet.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/git/GitInitSheet.kt
@@ -186,7 +186,7 @@ private fun doInit(
 ) {
   scope.launch {
     runCatching {
-      git.init(folder)
+      git.init(folder.asRawFile() ?: error("can't handle documents from other apps"))
       git.addAll()
     }.onSuccess { onSuccess() }.onFailure(onFailure)
   }

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/EditorViewModel.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/EditorViewModel.kt
@@ -104,7 +104,9 @@ class EditorViewModel : ViewModel() {
   }
 
   fun rememberLastFiles() {
-    val lastOpenedFiles = Gson().toJson(FileHistory(uiState.value.openedFiles.map { it.file.path }))
+    val lastOpenedFiles = Gson().toJson(FileHistory(uiState.value.openedFiles.mapNotNull{
+      if (it.file.canRestoreFromPath) it.file.path else null
+    }))
 
     viewModelScope.launch(Dispatchers.IO) {
       JFile(LAST_OPENED_FILES_JSON_PATH).apply {

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/DeleteFileDialog.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/DeleteFileDialog.kt
@@ -24,13 +24,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.blankj.utilcode.util.FileUtils
 import com.teixeira.vcspace.events.OnDeleteFileEvent
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.resources.R
 import com.teixeira.vcspace.utils.launchWithProgressDialog
 import com.teixeira.vcspace.utils.showShortToast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
-import java.io.File
 
 @Composable
 fun DeleteFileDialog(
@@ -54,7 +54,7 @@ fun DeleteFileDialog(
             builder.setCancelable(false)
           },
           action = { _, _ ->
-            val deleted = FileUtils.delete(file)
+            val deleted = file.delete()
 
             if (!deleted) {
               return@launchWithProgressDialog

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/EditorDrawerSheet.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/EditorDrawerSheet.kt
@@ -54,6 +54,7 @@ import com.teixeira.vcspace.events.OnCreateFileEvent
 import com.teixeira.vcspace.events.OnCreateFolderEvent
 import com.teixeira.vcspace.events.OnRefreshFolderEvent
 import com.teixeira.vcspace.extensions.openFile
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.git.GitViewModel
 import com.teixeira.vcspace.resources.R.string
 import com.teixeira.vcspace.ui.filetree.FileTree
@@ -64,10 +65,8 @@ import com.teixeira.vcspace.ui.screens.editor.components.drawer.NavRail
 import com.teixeira.vcspace.ui.screens.editor.components.drawer.OpenFolderActions
 import com.teixeira.vcspace.ui.screens.file.FileExplorerViewModel
 import com.teixeira.vcspace.utils.ApkInstaller
-import com.teixeira.vcspace.utils.isValidTextFile
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
-import java.io.File
 
 @Composable
 fun EditorDrawerSheet(
@@ -135,12 +134,12 @@ fun EditorDrawerSheet(
             ) {
               FileTree(
                 modifier = Modifier.weight(1f),
-                path = folder.absolutePath,
+                path = folder,
                 onFileClick = { file ->
                   if (!file.isDirectory) {
                     if (file.name.endsWith(".apk")) {
                       ApkInstaller.installApplication(context, file)
-                    } else if (isValidTextFile(file)) {
+                    } else if (file.isValidText) {
                       closeDrawer()
                       editorViewModel.addFile(file)
                     } else {

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/EditorTopBar.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/EditorTopBar.kt
@@ -94,6 +94,8 @@ import com.teixeira.vcspace.core.components.common.VCSpaceTopBar
 import com.teixeira.vcspace.core.settings.Settings.EditorTabs.rememberAutoSave
 import com.teixeira.vcspace.editor.events.OnContentChangeEvent
 import com.teixeira.vcspace.editor.events.OnKeyBindingEvent
+import com.teixeira.vcspace.file.extension
+import com.teixeira.vcspace.file.wrapFile
 import com.teixeira.vcspace.keyboard.model.Command.Companion.newCommand
 import com.teixeira.vcspace.plugins.internal.PluginManager
 import com.teixeira.vcspace.preferences.pythonDownloaded
@@ -111,7 +113,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.greenrobot.eventbus.EventBus
-import java.io.File
+import java.io.File as JFile
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -498,11 +500,11 @@ fun FileMenu(
   val createFile = rememberLauncherForActivityResult(
     ActivityResultContracts.CreateDocument("text/*")
   ) {
-    if (it != null) editorViewModel.addFile(UriUtils.uri2File(it))
+    if (it != null) editorViewModel.addFile(UriUtils.uri2File(it).wrapFile())
   }
 
   val openFile = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) {
-    if (it != null) editorViewModel.addFile(UriUtils.uri2File(it))
+    if (it != null) editorViewModel.addFile(UriUtils.uri2File(it).wrapFile())
   }
 
   val commandPaletteManager = LocalCommandPaletteManager.current
@@ -678,8 +680,8 @@ private fun extractPythonFile(
         }
       }
     ) { _, _ ->
-      File(filePath).inputStream().use { temp7zStream ->
-        val file = File("${context.filesDir.absolutePath}/python.7z").apply { createNewFile() }
+      JFile(filePath).inputStream().use { temp7zStream ->
+        val file = JFile("${context.filesDir.absolutePath}/python.7z").apply { createNewFile() }
         Files.copy(temp7zStream, file.toPath(), StandardCopyOption.REPLACE_EXISTING)
         val exitCode =
           P7ZipApi.executeCommand("7z x ${file.absolutePath} -o${context.filesDir.absolutePath}")
@@ -706,7 +708,7 @@ private fun downloadPythonPackage(
   }
 
   val url = if (Process.is64Bit()) PYTHON_PACKAGE_URL_64_BIT else PYTHON_PACKAGE_URL_32_BIT
-  val outputFile = File(context.filesDir, "python.7z")
+  val outputFile = JFile(context.filesDir, "python.7z")
 
   scope.launchWithProgressDialog(
     uiContext = context,

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/GitManager.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/GitManager.kt
@@ -78,6 +78,7 @@ import com.teixeira.vcspace.app.drawables
 import com.teixeira.vcspace.app.strings
 import com.teixeira.vcspace.compose.clipUrl
 import com.teixeira.vcspace.extensions.makePluralIf
+import com.teixeira.vcspace.file.wrapFile
 import com.teixeira.vcspace.git.GitActionStatus
 import com.teixeira.vcspace.git.GitManager.Companion.instance
 import com.teixeira.vcspace.git.GitViewModel
@@ -147,8 +148,9 @@ fun GitManager(
   }
 
   LaunchedEffect(openedFolder, isGitRepo) {
-    if (isGitRepo && openedFolder != null) {
-      gitViewModel.open(openedFolder ?: return@LaunchedEffect)
+    val jOpenedFolder = openedFolder?.asRawFile()
+    if (isGitRepo && jOpenedFolder != null) {
+      gitViewModel.open(jOpenedFolder)
     }
   }
 
@@ -173,12 +175,13 @@ fun GitManager(
     }
   }
 
-  if (showGitCloneDialog) {
+  val rawOpenedFolder = openedFolder?.asRawFile()
+  if (showGitCloneDialog && rawOpenedFolder != null ) {
     val url = clipUrl()
 
     GitCloneDialog(
       remoteUrl = url ?: "",
-      initialFolder = openedFolder,
+      initialFolder = rawOpenedFolder,
       onDismissRequest = { showGitCloneDialog = false },
       onCloneSuccess = {
         scope.launch {
@@ -186,7 +189,7 @@ fun GitManager(
             message = context.getString(R.string.successfully_cloned),
             icon = Icons.Rounded.Check
           )
-          fileExplorerViewModel.openFolder(it)
+          fileExplorerViewModel.openFolder(it.wrapFile())
 
           withContext(Dispatchers.Main) {
             navController.navigateSingleTop(EditorDrawerScreens.FileExplorer)

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/RenameFileDialog.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/RenameFileDialog.kt
@@ -28,13 +28,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.teixeira.vcspace.events.OnRenameFileEvent
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.resources.R
 import com.teixeira.vcspace.utils.launchWithProgressDialog
 import com.teixeira.vcspace.utils.showShortToast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.EventBus
-import java.io.File
 
 @Composable
 fun RenameFileDialog(
@@ -68,14 +68,9 @@ fun RenameFileDialog(
               builder.setCancelable(false)
             },
             action = { _, _ ->
-              val newFile = File(file.parentFile, fileName)
-              val renamed = file.renameTo(newFile)
+              val renamedFile = file.renameTo(fileName) ?: return@launchWithProgressDialog
 
-              if (!renamed) {
-                return@launchWithProgressDialog
-              }
-
-              EventBus.getDefault().post(OnRenameFileEvent(file, newFile, openedFolder))
+              EventBus.getDefault().post(OnRenameFileEvent(file, renamedFile, openedFolder))
 
               withContext(Dispatchers.Main) {
                 showShortToast(context, context.getString(R.string.file_renamed))

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/drawer/OpenFolderActions.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/drawer/OpenFolderActions.kt
@@ -15,6 +15,7 @@
 
 package com.teixeira.vcspace.ui.screens.editor.components.drawer
 
+import android.content.ContentResolver
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.basicMarquee
@@ -51,6 +52,8 @@ import com.blankj.utilcode.util.UriUtils
 import com.teixeira.vcspace.PreferenceKeys
 import com.teixeira.vcspace.app.strings
 import com.teixeira.vcspace.extensions.toFile
+import com.teixeira.vcspace.file.DocumentFileWrapper
+import com.teixeira.vcspace.file.wrapFile
 import com.teixeira.vcspace.preferences.defaultPrefs
 import com.teixeira.vcspace.resources.R
 import com.teixeira.vcspace.ui.screens.file.FileExplorerViewModel
@@ -68,7 +71,12 @@ fun OpenFolderActions(
     contract = ActivityResultContracts.OpenDocumentTree()
   ) { uri ->
     if (uri != null) DocumentFile.fromTreeUri(context, uri)?.let {
-      fileExplorerViewModel.openFolder(UriUtils.uri2File(it.uri))
+      val file = if (ContentResolver.SCHEME_CONTENT == it.uri.scheme) {
+        DocumentFileWrapper(it)
+      } else {
+        UriUtils.uri2File(it.uri).wrapFile()
+      }
+      fileExplorerViewModel.openFolder(file)
     }
   }
 
@@ -93,7 +101,7 @@ fun OpenFolderActions(
       onDismissRequest = { showRecentFoldersDialog = false },
       onOpenFolder = {
         val treeUri = DocumentFile.fromFile(it).uri
-        fileExplorerViewModel.openFolder(UriUtils.uri2File(treeUri))
+        fileExplorerViewModel.openFolder(UriUtils.uri2File(treeUri).wrapFile())
         showRecentFoldersDialog = false
       }
     )

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/drawer/OpenFolderActions.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/editor/components/drawer/OpenFolderActions.kt
@@ -71,7 +71,7 @@ fun OpenFolderActions(
     contract = ActivityResultContracts.OpenDocumentTree()
   ) { uri ->
     if (uri != null) DocumentFile.fromTreeUri(context, uri)?.let {
-      val file = if (ContentResolver.SCHEME_CONTENT == it.uri.scheme) {
+      val file = if (DocumentFileWrapper.shouldWrap(uri)) {
         DocumentFileWrapper(it)
       } else {
         UriUtils.uri2File(it.uri).wrapFile()

--- a/app/src/main/java/com/teixeira/vcspace/ui/screens/file/FileExplorerViewModel.kt
+++ b/app/src/main/java/com/teixeira/vcspace/ui/screens/file/FileExplorerViewModel.kt
@@ -20,13 +20,13 @@ import androidx.lifecycle.ViewModel
 import com.teixeira.vcspace.PreferenceKeys
 import com.teixeira.vcspace.events.OnOpenFolderEvent
 import com.teixeira.vcspace.events.OnRefreshFolderEvent
+import com.teixeira.vcspace.file.File
 import com.teixeira.vcspace.git.GitManager
 import com.teixeira.vcspace.preferences.defaultPrefs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import org.greenrobot.eventbus.EventBus
-import java.io.File
 
 class FileExplorerViewModel : ViewModel() {
   private val _openedFolder = MutableStateFlow<File?>(null)
@@ -53,7 +53,9 @@ class FileExplorerViewModel : ViewModel() {
 
   private fun updateGitRepoStatus(file: File) {
     _isGitRepo.update {
-      GitManager.isGitRepository(file).also { if (it) GitManager.instance.initialize(file) }
+      file.asRawFile()?.let { jfile ->
+        GitManager.isGitRepository(jfile).also { if (it) GitManager.instance.initialize(jfile) }
+      } ?: false
     }
   }
 

--- a/app/src/main/java/com/teixeira/vcspace/utils/ApkInstaller.kt
+++ b/app/src/main/java/com/teixeira/vcspace/utils/ApkInstaller.kt
@@ -3,10 +3,7 @@ package com.teixeira.vcspace.utils
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
-import androidx.core.content.FileProvider
-import com.teixeira.vcspace.BuildConfig
-import java.io.File
+import com.teixeira.vcspace.file.File
 
 /**
  * Adopted from:
@@ -15,7 +12,7 @@ import java.io.File
 object ApkInstaller {
   fun installApplication(context: Context, file: File) {
     val intent = Intent(Intent.ACTION_VIEW)
-    intent.setDataAndType(uriFromFile(context, file), "application/vnd.android.package-archive")
+    intent.setDataAndType(file.uri(context), "application/vnd.android.package-archive")
     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     try {
@@ -23,9 +20,5 @@ object ApkInstaller {
     } catch (e: ActivityNotFoundException) {
       e.printStackTrace()
     }
-  }
-
-  private fun uriFromFile(context: Context, file: File): Uri {
-    return FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
   }
 }

--- a/core/common/src/main/java/com/teixeira/vcspace/extensions/Context.kt
+++ b/core/common/src/main/java/com/teixeira/vcspace/extensions/Context.kt
@@ -21,7 +21,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.content.FileProvider
-import java.io.File
+import com.teixeira.vcspace.file.File
 
 fun <T> Context.open(clazz: Class<T>, newTask: Boolean = false) {
   val intent = Intent(this, clazz)
@@ -40,7 +40,7 @@ fun Context.getEmptyActivityBundle(): Bundle? {
 }
 
 fun Context.openFile(file: File) {
-  val uri = uriFromFile(file)
+  val uri = file.uri(this)
   val mimeType = contentResolver.getType(uri)
 
   Intent(Intent.ACTION_VIEW).apply {
@@ -49,9 +49,3 @@ fun Context.openFile(file: File) {
     startActivity(this)
   }
 }
-
-fun Context.uriFromFile(file: File): Uri = FileProvider.getUriForFile(
-  this,
-  "$packageName.provider",
-  file
-)

--- a/core/common/src/main/java/com/teixeira/vcspace/file/File.kt
+++ b/core/common/src/main/java/com/teixeira/vcspace/file/File.kt
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Visual Code Space.
+ *
+ * Visual Code Space is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Visual Code Space is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Visual Code Space.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This file is part of Visual Code Space.
+ *
+ * Visual Code Space is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * Visual Code Space is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Visual Code Space.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.teixeira.vcspace.file
+
+import android.content.Context
+import android.net.Uri
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import java.io.File as JFile
+
+/**
+ * Consolidated interface that blends multiple File access formats.
+ */
+interface File {
+  val absolutePath: String
+  val canonicalPath: String
+  val isDirectory: Boolean
+  val isFile: Boolean
+  val isValidText: Boolean
+  val name: String
+  val mimeType: String?
+  val parent: String?
+  val parentFile: File?
+  val path: String
+
+  fun asRawFile(): JFile?
+  fun childExists(childName: String): Boolean
+  fun createNewFile(fileName: String): File?
+  fun createNewDirectory(fileName: String): File?
+  fun delete(): Boolean
+  fun exists(): Boolean
+  fun lastModified(): Long
+  fun listFiles(): Array<out File>?
+  fun renameTo(newName: String): File?
+  fun uri(context: Context): Uri
+  suspend fun readFile2String(context: Context): String?
+  suspend fun write(
+    context: Context,
+    content: String,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ): Boolean
+}
+
+val File.extension: String
+  get() = name.substringAfterLast('.', "")

--- a/core/common/src/main/java/com/teixeira/vcspace/file/File.kt
+++ b/core/common/src/main/java/com/teixeira/vcspace/file/File.kt
@@ -42,6 +42,10 @@ import java.io.File as JFile
 interface File {
   val absolutePath: String
   val canonicalPath: String
+  /**
+   * true if this file can be restored from path
+   */
+  val canRestoreFromPath: Boolean
   val isDirectory: Boolean
   val isFile: Boolean
   val isValidText: Boolean

--- a/core/common/src/main/java/com/teixeira/vcspace/utils/FileUtils.kt
+++ b/core/common/src/main/java/com/teixeira/vcspace/utils/FileUtils.kt
@@ -21,7 +21,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Environment
 import androidx.core.content.ContextCompat
-import java.io.File
+import com.teixeira.vcspace.file.File
+import com.teixeira.vcspace.file.extension
+import java.io.File as JFile
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -31,7 +33,7 @@ val INVALID_TEXT_FILES_REGEX =
     ".*\\.(bin|ttf|png|jpe?g|bmp|mp4|mp3|m4a|iso|so|zip|rar|jar|dex|odex|vdex|7z|apk|apks|xapk)$"
   )
 
-fun isValidTextFile(file: File): Boolean {
+fun isValidTextFile(file: JFile): Boolean {
   val type = Files.probeContentType(Paths.get(file.absolutePath))
 
   // A comprehensive list of known text-based MIME types

--- a/feature/editor/src/main/java/com/teixeira/vcspace/editor/VCSpaceEditor.kt
+++ b/feature/editor/src/main/java/com/teixeira/vcspace/editor/VCSpaceEditor.kt
@@ -23,12 +23,12 @@ import com.teixeira.vcspace.editor.completion.CompletionListAdapter
 import com.teixeira.vcspace.editor.completion.CustomCompletionLayout
 import com.teixeira.vcspace.editor.listener.OnExplainCodeListener
 import com.teixeira.vcspace.editor.listener.OnImportComponentListener
+import com.teixeira.vcspace.file.File
 import io.github.rosemoe.sora.langs.textmate.TextMateLanguage
 import io.github.rosemoe.sora.widget.CodeEditor
 import io.github.rosemoe.sora.widget.component.EditorAutoCompletion
 import io.github.rosemoe.sora.widget.component.EditorTextActionWindow
 import org.eclipse.tm4e.languageconfiguration.internal.model.CommentRule
-import java.io.File
 
 class VCSpaceEditor @JvmOverloads constructor(
   context: Context,

--- a/feature/editor/src/main/java/com/teixeira/vcspace/editor/events/editorEvents.kt
+++ b/feature/editor/src/main/java/com/teixeira/vcspace/editor/events/editorEvents.kt
@@ -15,7 +15,7 @@
 
 package com.teixeira.vcspace.editor.events
 
-import java.io.File
+import com.teixeira.vcspace.file.File
 
 data class OnContentChangeEvent(
   val file: File?


### PR DESCRIPTION
Editing files from other apps like Termux need to use DocumentFile or DocumentsContract. DocumentFile does have RawDocumentFile but the majority of the codebase uses File based APIs so File[Wrapper] currently just called File to reduce merge conflicts brings DocumentFile APIs closer to File APIs. Some APIs like new file/dir APIs were harder to emulate so they were changed to be closer to DocumentFile APIs.