### PR TITLE
fix(editor): clear command palette in initCommands to avoid stale act…

### DIFF
--- a/app/src/main/java/com/teixeira/vcspace/activities/EditorActivity.kt
+++ b/app/src/main/java/com/teixeira/vcspace/activities/EditorActivity.kt
@@ -386,7 +386,9 @@ class EditorActivity : BaseComposeActivity() {
     }
 
     private fun initCommands() {
-        //CommandPaletteManager.instance.clear()
+        // Reset so Compose-registered commands (e.g. Open File with ActivityResultLauncher)
+        // from a previous activity instance cannot run after their launchers are unregistered.
+        CommandPaletteManager.instance.clear()
         CommandPaletteManager.instance.addCommand(
             newCommand("Paste", "Ctrl+V") {
                 if (currentEditor !is CodeEditorView) return@newCommand


### PR DESCRIPTION
IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher means openFile.launch(...) ran while that ActivityResultLauncher was no longer registered with the activity’s ActivityResultRegistry.

##Fix applied

initCommands() already had a commented-out reset. Turning it on clears the palette when each EditorActivity is created, so old launcher-backed commands are dropped before initCommands() re-registers static commands. FileMenu / drawer / top bar LaunchedEffects then register fresh handlers with the current launchers. Plugins still call addCommand after load as before.

Change: call CommandPaletteManager.instance.clear() at the start of initCommands() in EditorActivity.kt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a state management issue where command registrations from previous editor sessions could persist and execute unexpectedly in new sessions, ensuring the editor starts with a clean state each time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->